### PR TITLE
Step4task4 (task5 in JA)

### DIFF
--- a/python/dockerfile
+++ b/python/dockerfile
@@ -5,5 +5,5 @@ COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 COPY . .
 
-# STEP4-4では以下は変更しない
+# STEP4-4では以下は変更しない。
 CMD ["python", "-V"]

--- a/python/dockerfile
+++ b/python/dockerfile
@@ -5,5 +5,5 @@ COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 COPY . .
 
-# STEP4-4では以下は変更しない。
-CMD ["python", "-V"]
+# STEP4-4では以下は変更しない
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "9000" ]

--- a/python/dockerfile
+++ b/python/dockerfile
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+FROM python:3.8-slim-buster
+WORKDIR /app
+COPY requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt
+COPY . .
+
+# STEP4-4では以下は変更しない
+CMD ["python", "-V"]


### PR DESCRIPTION
## What
Modified the dockerfile so that you can use the same version of Python as STEP2 (Python 3.8.13) in your docker image.

## CHECKS :warning:

1. Clone this branch 
```
$ git clone -b step4task5 git@github.com:mikan373/mercari-build-training-2022.git
```
2. In `python` directory, build a docker image 
```
docker build -t build2022/app:latest .
```
3. Run the image
```
docker run build2022/app
```
4. Check if it returns below
```
Python 3.8.13
```

Please make sure you are aware of the following.

- [ ] **The changes in this PR doesn't have private information
